### PR TITLE
add ensure_fork_safe

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "FUJIWARA Shunichiro <fujiwara.shunichiro@gmail.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.0.4, CPAN::Meta::Converter version 2.150005",
+   "generated_by" : "Minilla/v3.0.11, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
@@ -51,6 +51,7 @@
       "test" : {
          "requires" : {
             "Test::More" : "0.98",
+            "Test::SharedFork" : "0",
             "Test::TCP" : "0"
          }
       }
@@ -69,5 +70,5 @@
    },
    "version" : "0.1",
    "x_authority" : "cpan:FUJIWARA",
-   "x_serialization_backend" : "JSON::PP version 2.27300"
+   "x_serialization_backend" : "JSON::PP version 2.27400_02"
 }

--- a/cpanfile
+++ b/cpanfile
@@ -3,6 +3,7 @@ requires 'perl', '5.008001';
 on 'test' => sub {
     requires 'Test::More', '0.98';
     requires 'Test::TCP';
+    requires 'Test::SharedFork';
 };
 
 requires 'Class::Tiny';

--- a/lib/Katsubushi/Client.pm
+++ b/lib/Katsubushi/Client.pm
@@ -17,6 +17,7 @@ use Class::Tiny +{
             Cache::Memcached::Fast->new({ servers => [ $_ ] });
         } @{$self->servers} ];
     },
+    pid => sub { $$ },
 };
 
 sub BUILD {
@@ -30,6 +31,7 @@ sub BUILD {
 sub fetch {
     my $self = shift;
 
+    $self->ensure_fork_safe;
     my $id = 0;
 
     # retry at once for only main (the first of list) server
@@ -48,6 +50,9 @@ sub fetch {
 sub fetch_multi {
     my $self = shift;
     my $n    = shift;
+
+    $self->ensure_fork_safe;
+
     my @keys = ( 1 .. $n );
     my $ids;
     # retry at once for only main (the first of list) server
@@ -61,6 +66,19 @@ sub fetch_multi {
     }
 
     return map { $ids->{$_} } @keys;
+}
+
+sub ensure_fork_safe {
+    my $self = shift;
+
+    if ($self->pid != $$) {
+        # detect forked
+        $self->pid($$);
+        for my $memd (@{$self->_models}) {
+            $memd->disconnect_all;
+        }
+    }
+    1;
 }
 
 1;

--- a/t/04_fork.t
+++ b/t/04_fork.t
@@ -1,0 +1,41 @@
+use strict;
+use Test::More 0.98;
+use Test::TCP;
+use Test::SharedFork;
+use Katsubushi::Client;
+
+my $version = qx{katsubushi -version};
+if (  $version !~ /katsubushi version:/  ) {
+    Test::More::plan skip_all => "katsubushi is not installed.";
+}
+
+my $server = Test::TCP->new(
+    code => sub {
+        my $port = shift;
+        exec "katsubushi", "-port", $port, "-worker-id", 1, "-log-level", "debug";
+    },
+);
+
+my $client = Katsubushi::Client->new({
+    servers => ["localhost:" . $server->port],
+});
+my $id = $client->fetch;
+ok $id;
+explain $id;
+
+my $pid = fork();
+if ($pid == 0) {
+    Test::SharedFork->child;
+    my $id2 = $client->fetch;
+    ok $id2;
+}
+elsif (defined $pid) {
+    Test::SharedFork->parent;
+    waitpid $pid, 0;
+    my $id3 = $client->fetch;
+    ok $id3;
+    done_testing;
+} else {
+    die "Cannot fork: $!";
+};
+


### PR DESCRIPTION
Cache::Mecached::Fast is not a fork safe.
When a process forked detected, call C::M::F->disconnect_all for renew a connection to katsubushi.
